### PR TITLE
Fix Vue integration and add setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,25 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Project Setup
+
+1. Install PHP dependencies:
+   ```bash
+   composer install
+   ```
+2. Install JavaScript dependencies:
+   ```bash
+   npm install
+   ```
+3. Copy the example environment file and generate the application key:
+   ```bash
+   cp .env.example .env
+   php artisan key:generate
+   ```
+4. Run the development servers:
+   ```bash
+   php artisan serve
+   npm run dev
+   ```
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "treinamento",
+    "name": "pwa",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/js/components/ExampleComponent.vue
+++ b/resources/js/components/ExampleComponent.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>Hello from Vue</div>
+</template>
+
+<script>
+export default {
+  name: 'ExampleComponent'
+}
+</script>
+
+<style scoped>
+</style>
+


### PR DESCRIPTION
## Summary
- add missing ExampleComponent.vue
- document project setup steps in README
- update project name in package-lock.json

## Testing
- `composer install`
- `npm install`
- `vendor/bin/phpunit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6865e5819a34832cbadc6e47511929c8