### PR TITLE
Add finance control example with Vue

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,6 +1,9 @@
 import './bootstrap';
 import { createApp } from 'vue';
 import Wellcomee from './components/Wellcomee.vue';
+import FinanceControl from './components/FinanceControl.vue';
 
-createApp({}).component('wellcomee', Wellcomee).mount('#app');
-
+createApp({})
+    .component('wellcomee', Wellcomee)
+    .component('finance-control', FinanceControl)
+    .mount('#app');

--- a/resources/js/components/FinanceControl.vue
+++ b/resources/js/components/FinanceControl.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="max-w-md mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">Controle Financeiro</h1>
+
+    <form @submit.prevent="addEntry" class="mb-4">
+      <div class="flex space-x-2 mb-2">
+        <input v-model="newEntry.description" placeholder="Descrição" class="border p-2 flex-1" />
+        <input v-model.number="newEntry.amount" type="number" placeholder="Valor" class="border p-2 w-24" />
+      </div>
+      <button type="submit" class="bg-blue-500 text-white px-4 py-1 rounded">Adicionar</button>
+    </form>
+
+    <ul>
+      <li v-for="(entry, index) in entries" :key="index" class="flex justify-between mb-2">
+        <span>{{ entry.description }}</span>
+        <span :class="{ 'text-green-600': entry.amount >= 0, 'text-red-600': entry.amount < 0 }">
+          {{ currency(entry.amount) }}
+        </span>
+      </li>
+    </ul>
+
+    <div class="mt-4 font-bold">Total: {{ currency(total) }}</div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'FinanceControl',
+  data() {
+    return {
+      entries: [],
+      newEntry: {
+        description: '',
+        amount: null,
+      },
+    };
+  },
+  computed: {
+    total() {
+      return this.entries.reduce((sum, e) => sum + parseFloat(e.amount), 0);
+    },
+  },
+  methods: {
+    addEntry() {
+      if (!this.newEntry.description || this.newEntry.amount === null) {
+        return;
+      }
+      this.entries.push({
+        description: this.newEntry.description,
+        amount: this.newEntry.amount,
+      });
+      this.newEntry.description = '';
+      this.newEntry.amount = null;
+    },
+    currency(value) {
+      return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+    },
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/resources/js/components/Wellcomee.vue
+++ b/resources/js/components/Wellcomee.vue
@@ -1,13 +1,18 @@
 <template>
-  <div>Bem-vindo ao componente Wellcomee</div>
+  <div class="p-4">
+    <h1 class="text-xl font-bold mb-4">Bem-vindo ao Controle Financeiro</h1>
+    <finance-control />
+  </div>
 </template>
 
 <script>
+import FinanceControl from './FinanceControl.vue';
+
 export default {
-  name: 'Wellcomee'
-}
+  name: 'Welcome',
+  components: { FinanceControl },
+};
 </script>
 
 <style scoped>
 </style>
-

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
-
+<html lang="pt-BR">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <title>Laravel</title>
-
+    <title>Controle Financeiro</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="antialiased">
     <div id="app">
         <wellcomee />
     </div>
-
-    </html>
-</head>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a simple FinanceControl Vue component
- update Wellcomee component to include FinanceControl
- register components in app.js
- clean up welcome blade with Vite assets and use the new components

## Testing
- `composer test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6865eefccc8c832cb688d581f214ef49