### PR TITLE
Add Bootstrap CDN

### DIFF
--- a/resources/js/components/FinanceControl.vue
+++ b/resources/js/components/FinanceControl.vue
@@ -49,6 +49,13 @@
 </template>
 
 <script>
+if (typeof window !== 'undefined' && !document.getElementById('bootstrap-cdn-js')) {
+  const bootstrapScript = document.createElement('script');
+  bootstrapScript.id = 'bootstrap-cdn-js';
+  bootstrapScript.src = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js';
+  document.head.appendChild(bootstrapScript);
+}
+
 export default {
   name: 'FinanceControl',
   data() {
@@ -84,5 +91,6 @@ export default {
 };
 </script>
 
-<style scoped>
+<style>
+@import url('https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css');
 </style>

--- a/resources/js/components/Wellcomee.vue
+++ b/resources/js/components/Wellcomee.vue
@@ -8,6 +8,13 @@
 </template>
 
 <script>
+if (typeof window !== 'undefined' && !document.getElementById('bootstrap-cdn-js')) {
+  const bootstrapScript = document.createElement('script');
+  bootstrapScript.id = 'bootstrap-cdn-js';
+  bootstrapScript.src = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js';
+  document.head.appendChild(bootstrapScript);
+}
+
 import FinanceControl from './FinanceControl.vue';
 
 export default {
@@ -16,5 +23,6 @@ export default {
 };
 </script>
 
-<style scoped>
+<style>
+@import url('https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css');
 </style>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,6 +5,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Controle Financeiro</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Load application scripts compiled by Vite -->
     @vite(['resources/js/app.js'])
 </head>


### PR DESCRIPTION
## Summary
- embed Bootstrap CDN in Vue components
- load Bootstrap CDN in the welcome page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_686896f4163c832c8a6fc1b9607751a2