### PR TITLE
Replace CDN Bootstrap with local package

### DIFF
--- a/resources/js/components/FinanceControl.vue
+++ b/resources/js/components/FinanceControl.vue
@@ -49,13 +49,6 @@
 </template>
 
 <script>
-if (typeof window !== 'undefined' && !document.getElementById('bootstrap-cdn-js')) {
-  const bootstrapScript = document.createElement('script');
-  bootstrapScript.id = 'bootstrap-cdn-js';
-  bootstrapScript.src = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js';
-  document.head.appendChild(bootstrapScript);
-}
-
 export default {
   name: 'FinanceControl',
   data() {
@@ -90,7 +83,3 @@ export default {
   },
 };
 </script>
-
-<style>
-@import url('https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css');
-</style>

--- a/resources/js/components/Wellcomee.vue
+++ b/resources/js/components/Wellcomee.vue
@@ -8,13 +8,6 @@
 </template>
 
 <script>
-if (typeof window !== 'undefined' && !document.getElementById('bootstrap-cdn-js')) {
-  const bootstrapScript = document.createElement('script');
-  bootstrapScript.id = 'bootstrap-cdn-js';
-  bootstrapScript.src = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js';
-  document.head.appendChild(bootstrapScript);
-}
-
 import FinanceControl from './FinanceControl.vue';
 
 export default {
@@ -23,6 +16,3 @@ export default {
 };
 </script>
 
-<style>
-@import url('https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css');
-</style>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,10 +5,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Controle Financeiro</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"></script>
-    <!-- Load application scripts compiled by Vite -->
-    @vite(['resources/js/app.js'])
+    <!-- Load application assets compiled by Vite -->
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- use local Bootstrap assets in Laravel view
- drop CDN loading from Vue components

## Testing
- `npm run build`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68691fb317ac832c95a44d7d5f7f3591